### PR TITLE
Fixed #42. Use md5 hash for file name to avoid multipart/form-data errors

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -1,3 +1,4 @@
+import {createHash} from "crypto";
 import {EventEmitter} from "events";
 import * as ReportPortalClient from "reportportal-client";
 import {EVENTS, LEVEL, STATUS, TYPE} from "./constants";
@@ -310,8 +311,9 @@ class ReportPortalReporter extends EventEmitter {
       message: "",
       time: this.now(),
     };
-
-    const promise = ReportPortalReporter.client.getRequestLogWithFile(saveLogRQ, { name, content, type });
+    // to avoid https://github.com/BorisOsipov/wdio-reportportal-reporter/issues/42#issuecomment-456573592
+    const fileName = createHash("md5").update(name).digest("hex");
+    const promise = ReportPortalReporter.client.getRequestLogWithFile(saveLogRQ, { name: fileName, content, type });
     promiseErrorHandler(promise);
   }
 

--- a/test/fixtures/specs/failing.js
+++ b/test/fixtures/specs/failing.js
@@ -16,4 +16,9 @@ describe('test footer', function () {
     assert.isTrue(false, 'test 2 failed')
   })
 
+  it('Verify saving/unsaving a recipe from RDP for FT user -env prod -feature freetrial', function () {
+    browser.url('https://www.google.com');
+    assert.isTrue(false, 'test should fail!!!!!')
+  });
+
 });


### PR DESCRIPTION
Fixed #42. Use md5 hash for file name to avoid multipart/form-data errors

