### PR TITLE
Feature/jp support cucumber nested steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # JetBrains IDE
 .idea
+
+# VS Code IDE
+.vscode

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ const conf = {
   seleniumCommandsLogLevel: 'debug',
   screenshotsLogLevel: 'info',
   parseTagsFromTestTitle: false,
+  cucumberNestedSteps: false,
+  autoAttachCucumberFeatureToScenario: false // requires cucumberNestedSteps to be true for use
 };
 
 exports.config = {

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -9,5 +9,6 @@ export default class ReporterOptions {
   public parseTagsFromTestTitle = false;
   public setRetryTrue = false;
   public cucumberNestedSteps = false;
+  public autoAttachCucumberFeatureToScenario = false;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, tags: [], description: ""};
 }

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -8,5 +8,6 @@ export default class ReporterOptions {
   public seleniumCommandsLogLevel = LEVEL.DEBUG;
   public parseTagsFromTestTitle = false;
   public setRetryTrue = false;
+  public cucumberNestedSteps = false;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, tags: [], description: ""};
 }

--- a/lib/__tests__/endSuite.spec.ts
+++ b/lib/__tests__/endSuite.spec.ts
@@ -1,0 +1,73 @@
+import {CUCUMBER_STATUS, CUCUMBER_TYPE, STATUS} from "../constants";
+import {suiteEndEvent, suiteStartEvent} from "./fixtures/events";
+import {getOptions, RPClient} from "./reportportal-client.mock";
+
+const Reporter = require("../../build/reporter");
+
+describe("endSuite", () => {
+  let reporter: any;
+
+  beforeEach(() => {
+    reporter = new Reporter(getOptions());
+    reporter.client = new RPClient();
+    reporter.tempLaunchId = "tempLaunchId";
+    reporter.onSuiteStart(suiteStartEvent());
+  });
+
+  test("should endSuite", () => {
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.onSuiteEnd(suiteEndEvent());
+
+    expect(reporter.client.finishTestItem).toBeCalledTimes(1);
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {status: STATUS.PASSED},
+    );
+  });
+
+  test("should set status as passing for cucumber nested steps", () => {
+    Object.assign(reporter.options, {cucumberNestedSteps: true});
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.onSuiteEnd(Object.assign(
+      suiteEndEvent(),
+      {
+        tests: [
+          {
+            state: CUCUMBER_STATUS.PASSED,
+          },
+          {
+            state: CUCUMBER_STATUS.PASSED,
+          },
+        ],
+        type: CUCUMBER_TYPE.SCENARIO,
+      }));
+
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {status: STATUS.PASSED},
+    );
+  });
+
+  test("should set status as failing for cucumber nested steps", () => {
+    Object.assign(reporter.options, {cucumberNestedSteps: true});
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.onSuiteEnd(Object.assign(
+      suiteEndEvent(),
+      {
+        tests: [
+          {
+            state: CUCUMBER_STATUS.FAILED,
+          },
+          {
+            state: CUCUMBER_STATUS.PASSED,
+          },
+        ],
+        type: CUCUMBER_TYPE.SCENARIO,
+      }));
+
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {status: STATUS.FAILED},
+    );
+  });
+});

--- a/lib/__tests__/fixtures/events.ts
+++ b/lib/__tests__/fixtures/events.ts
@@ -1,2 +1,2 @@
 export const suiteStartEvent = () => ({cid: "0-0", title: "foo", runner: {"0-0": {}}});
-export const suiteEndEvent = {cid: "0-0", title: "foo"};
+export const suiteEndEvent = () => ({cid: "0-0", title: "foo"});

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -1,4 +1,4 @@
-import {TYPE} from "../constants";
+import {CUCUMBER_TYPE, STATUS, TYPE} from "../constants";
 import {suiteStartEvent} from "./fixtures/events";
 import {getOptions, RPClient} from "./reportportal-client.mock";
 
@@ -51,6 +51,43 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       2,
       {name: "foo", type: TYPE.SUITE, retry: false},
+      reporter.tempLaunchId,
+      id,
+    );
+  });
+
+  test("should support cucumber nested steps", () => {
+    Object.assign(reporter.options, {cucumberNestedSteps: true});
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.FEATURE}));
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.SCENARIO}));
+
+    expect(reporter.client.startTestItem).toBeCalledTimes(2);
+    expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
+      1,
+      {name: "foo", type: TYPE.TEST, retry: false},
+      reporter.tempLaunchId,
+      null,
+    );
+
+    const {id} = reporter.storage.getCurrentSuite();
+    expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
+      2,
+      {name: "foo", type: TYPE.STEP, retry: false},
+      reporter.tempLaunchId,
+      id,
+    );
+  });
+
+  test("should add attribute with feature name to scenario", () => {
+    Object.assign(reporter.options, {cucumberNestedSteps: true, autoAttachCucumberFeatureToScenario: true});
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.FEATURE, title: "foo"}));
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.SCENARIO}));
+
+    expect(reporter.featureName).toEqual("foo");
+    const {id} = reporter.storage.getCurrentSuite();
+    expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
+      2,
+      {name: "foo", type: TYPE.STEP, retry: false, attributes: [{key: CUCUMBER_TYPE.FEATURE, value: "foo"}]},
       reporter.tempLaunchId,
       id,
     );

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -1,4 +1,4 @@
-import {CUCUMBER_TYPE, STATUS, TYPE} from "../constants";
+import {CUCUMBER_TYPE, TYPE} from "../constants";
 import {suiteStartEvent} from "./fixtures/events";
 import {getOptions, RPClient} from "./reportportal-client.mock";
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -42,6 +42,16 @@ export enum TYPE {
   AFTER_TEST = "AFTER_TEST",
 }
 
+export enum CUCUMBER_TYPE {
+  FEATURE = "feature",
+  SCENARIO = "scenario"
+}
+
+export enum CUCUMBER_STATUS {
+  PASSED = "passed",
+  FAILED = "failed"
+}
+
 export enum MODE {
   DEFAULT = "DEFAULT",
   DEBUG = "DEBUG",

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -44,12 +44,12 @@ export enum TYPE {
 
 export enum CUCUMBER_TYPE {
   FEATURE = "feature",
-  SCENARIO = "scenario"
+  SCENARIO = "scenario",
 }
 
 export enum CUCUMBER_STATUS {
   PASSED = "passed",
-  FAILED = "failed"
+  FAILED = "failed",
 }
 
 export enum MODE {

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -10,6 +10,7 @@ export class StartTestItem {
   public type: TYPE;
   public codeRef: string;
   public retry = false;
+  public hasStats: boolean;
 
   constructor(name: string, type: TYPE) {
     this.name = name;

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -52,6 +52,7 @@ class ReportPortalReporter extends Reporter {
   private rpPromisesCompleted = false;
   private specFile: string;
   private featureStatus: STATUS;
+  private featureName: string;
 
   constructor(options: any) {
     super(Object.assign({stdout: true}, options));
@@ -69,6 +70,22 @@ class ReportPortalReporter extends Reporter {
     const suiteStartObj = this.options.cucumberNestedSteps ?
       new StartTestItem(suite.title, suite.type === CUCUMBER_TYPE.FEATURE ? TYPE.TEST : TYPE.STEP) :
       new StartTestItem(suite.title, TYPE.SUITE);
+
+    if (this.options.cucumberNestedSteps && this.options.autoAttachCucumberFeatureToScenario) {
+      switch(suite.type) {
+        case CUCUMBER_TYPE.FEATURE:
+          this.featureName = suite.title
+          break;
+        case CUCUMBER_TYPE.SCENARIO:
+          suiteStartObj.attributes = [
+            {
+              key: CUCUMBER_TYPE.FEATURE,
+              value: this.featureName
+            }
+          ];
+          break;
+      }
+    }
 
     const suiteItem = this.storage.getCurrentSuite();
     let parentId = null;

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -3,7 +3,7 @@ import Reporter from "@wdio/reporter";
 import {createHash} from "crypto";
 import * as path from "path";
 import * as ReportPortalClient from "reportportal-js-client";
-import {EVENTS, LEVEL, STATUS, TYPE} from "./constants";
+import {EVENTS, LEVEL, STATUS, TYPE, CUCUMBER_TYPE, CUCUMBER_STATUS} from "./constants";
 import {EndTestItem, Issue, StartTestItem, StorageEntity} from "./entities";
 import ReporterOptions from "./ReporterOptions";
 import {Storage} from "./storage";
@@ -51,16 +51,25 @@ class ReportPortalReporter extends Reporter {
   private sanitizedCapabilities: string;
   private rpPromisesCompleted = false;
   private specFile: string;
+  private featureStatus: STATUS;
 
   constructor(options: any) {
     super(Object.assign({stdout: true}, options));
     this.options = Object.assign(new ReporterOptions(), options);
     this.registerListeners();
+
+    if (this.options.cucumberNestedSteps) {
+      this.featureStatus = STATUS.PASSED;
+    }
   }
 
   private onSuiteStart(suite: any) {
     log.trace(`Start suite ${suite.title} ${suite.uid}`);
-    const suiteStartObj = new StartTestItem(suite.title, TYPE.SUITE);
+
+    const suiteStartObj = this.options.cucumberNestedSteps ?
+      new StartTestItem(suite.title, suite.type === CUCUMBER_TYPE.FEATURE ? TYPE.TEST : TYPE.STEP) :
+      new StartTestItem(suite.title, TYPE.SUITE);
+
     const suiteItem = this.storage.getCurrentSuite();
     let parentId = null;
     if (suiteItem !== null) {
@@ -81,8 +90,23 @@ class ReportPortalReporter extends Reporter {
 
   private onSuiteEnd(suite: any) {
     log.trace(`End suite ${suite.title} ${suite.uid}`);
+
+    let status = STATUS.PASSED;
+    if (this.options.cucumberNestedSteps) {
+      switch(suite.type) {
+        case CUCUMBER_TYPE.SCENARIO:
+          const scenarioStatus = suite.tests.every(({ state }) => state === CUCUMBER_STATUS.PASSED);
+          status = scenarioStatus ? STATUS.PASSED : STATUS.FAILED;
+          this.featureStatus = this.featureStatus === STATUS.PASSED && status === STATUS.PASSED ? STATUS.PASSED : STATUS.FAILED;
+          break;
+        case CUCUMBER_TYPE.FEATURE:
+          status = this.featureStatus;
+          break;
+      }
+    }
+
     const suiteItem = this.storage.getCurrentSuite();
-    const finishSuiteObj = {status: STATUS.PASSED};
+    const finishSuiteObj = {status};
     const {promise} = this.client.finishTestItem(suiteItem.id, finishSuiteObj);
     promiseErrorHandler(promise);
     this.storage.removeSuite();
@@ -96,6 +120,10 @@ class ReportPortalReporter extends Reporter {
     const suite = this.storage.getCurrentSuite();
     const testStartObj = new StartTestItem(test.title, type);
     testStartObj.codeRef = this.specFile;
+
+    if (this.options.cucumberNestedSteps) {
+      testStartObj.hasStats = false;
+    }
     if (this.options.parseTagsFromTestTitle) {
       testStartObj.addTags();
     }

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -3,7 +3,7 @@ import Reporter from "@wdio/reporter";
 import {createHash} from "crypto";
 import * as path from "path";
 import * as ReportPortalClient from "reportportal-js-client";
-import {EVENTS, LEVEL, STATUS, TYPE, CUCUMBER_TYPE, CUCUMBER_STATUS} from "./constants";
+import {CUCUMBER_STATUS, CUCUMBER_TYPE, EVENTS, LEVEL, STATUS, TYPE} from "./constants";
 import {EndTestItem, Issue, StartTestItem, StorageEntity} from "./entities";
 import ReporterOptions from "./ReporterOptions";
 import {Storage} from "./storage";
@@ -72,16 +72,16 @@ class ReportPortalReporter extends Reporter {
       new StartTestItem(suite.title, TYPE.SUITE);
 
     if (this.options.cucumberNestedSteps && this.options.autoAttachCucumberFeatureToScenario) {
-      switch(suite.type) {
+      switch (suite.type) {
         case CUCUMBER_TYPE.FEATURE:
-          this.featureName = suite.title
+          this.featureName = suite.title;
           break;
         case CUCUMBER_TYPE.SCENARIO:
           suiteStartObj.attributes = [
             {
               key: CUCUMBER_TYPE.FEATURE,
-              value: this.featureName
-            }
+              value: this.featureName,
+            },
           ];
           break;
       }
@@ -110,7 +110,7 @@ class ReportPortalReporter extends Reporter {
 
     let status = STATUS.PASSED;
     if (this.options.cucumberNestedSteps) {
-      switch(suite.type) {
+      switch (suite.type) {
         case CUCUMBER_TYPE.SCENARIO:
           const scenarioStatus = suite.tests.every(({ state }) => state === CUCUMBER_STATUS.PASSED);
           status = scenarioStatus ? STATUS.PASSED : STATUS.FAILED;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-reportportal-reporter",
-  "version": "5.3.0",
+  "version": "5.2.4",
   "description": "A WebdriverIO v5 plugin. Report results to Report Portal.",
   "main": "build/reporter.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdio-reportportal-reporter",
-  "version": "5.2.4",
+  "version": "5.3.0",
   "description": "A WebdriverIO v5 plugin. Report results to Report Portal.",
   "main": "build/reporter.js",
   "scripts": {


### PR DESCRIPTION
## Proposed changes
ReportPortal release v5 comes with the ability to have nested steps which for Cucumber is useful so that the reporting is at the Scenario level rather than the Step level.  Currently the reporting displays the total number of Steps for all Scenarios and this allows it to display the total number of Scenarios instead.  It follows the approach used in the [reportportal-agent-cucumber](https://github.com/reportportal/agent-js-cucumber).  A new flag, `cucumberNestedSteps`, was added since the implementation is specific to cucumber.

Another addition is an option to add an attribute with the feature name to each scenario so that that Component Health widget can be used to display the health of each Feature.  To use this feature, it is required to have the nested steps option (`cucumberNestedSteps`) also applied.

