### PR TITLE
Send error log to suite/scenario

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -198,6 +198,14 @@ class ReportPortalReporter extends Reporter {
         level: LEVEL.ERROR,
         message,
       });
+
+      if (this.options.cucumberNestedSteps) {
+        const suiteItem = this.storage.getCurrentSuite();
+        this.client.sendLog(suiteItem.id, {
+          level: LEVEL.ERROR,
+          message,
+        });
+      }
     }
 
     const {promise} = this.client.finishTestItem(testItem.id, finishTestObj);


### PR DESCRIPTION
Currently when using the cucumberNestedSteps flag, the report portal auto-analysis doesn't work. Through some trial and error it appears that attached the error log to the suite (scenario) which is set as type TEST in report portal will include the log in the analysis. Not sure if this is the best approach, however it's been tested and does work. Any feedback is greatly appreciated!