### PR TITLE
Mark fields optional to prevent tsc error messages

### DIFF
--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -4,13 +4,13 @@ import {parseTags} from "./utils";
 
 export class StartTestItem {
   public name = "";
-  public description;
+  public description?: string;
   public parameters?: any[];
   public attributes = [];
   public type: TYPE;
-  public codeRef: string;
+  public codeRef?: string;
   public retry = false;
-  public hasStats: boolean;
+  public hasStats?: boolean;
 
   constructor(name: string, type: TYPE) {
     this.name = name;


### PR DESCRIPTION
## Proposed changes
When compiling a project via tsc the following error messages appear:

```
node_modules/wdio-reportportal-reporter/lib/entities.ts:6:10 - error TS7008: Member 'description' implicitly has an 'any' type.

6   public description;
           ~~~~~~~~~~~

node_modules/wdio-reportportal-reporter/lib/entities.ts:11:10 - error TS2564: Property 'codeRef' has no initializer and is not definitely assigned in the constructor.

11   public codeRef: string;
            ~~~~~~~

node_modules/wdio-reportportal-reporter/lib/entities.ts:13:10 - error TS2564: Property 'hasStats' has no initializer and is not definitely assigned in the constructor.

13   public hasStats: boolean;
```

This pr defines an explicit type for the description field and marks all three fields as optional to circumvent these error messages.

