### PR TITLE
Retry Cucumber Scenarios

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -84,6 +84,10 @@ class ReportPortalReporter extends Reporter {
               value: this.featureName,
             },
           ];
+
+          if (this.options.setRetryTrue) {
+            suiteStartObj.retry = true;
+          }
           break;
       }
     }


### PR DESCRIPTION
## Proposed changes
Current retry option doesn't work for Cucumber unless you have the `scenarioLevelReporter` set to `true`.  However, doing that will not show steps in Report Portal.  This change sets the retry at the scenario level.  It does require `scenarioLevelReporter` being set to `false` so the steps are still reported.

