### PR TITLE
Code reference

### DIFF
--- a/lib/__tests__/utils.spec.ts
+++ b/lib/__tests__/utils.spec.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import {TYPE} from "../constants";
 import {StartTestItem} from "../entities";
 import {
@@ -6,7 +7,8 @@ import {
   addSauceLabAttributes,
   isScreenshotCommand,
   parseTags,
-  sendToReporter
+  sendToReporter,
+  addCodeRef
 } from "../utils";
 import {getDefaultOptions} from "./reportportal-client.mock";
 
@@ -109,11 +111,11 @@ describe("#addSauceLabAttributes",  () => {
   test("can use old config param isSauseLabRun", () => {
     const testItem = new StartTestItem("name", TYPE.STEP);
     const reporterOptions = getDefaultOptions();
-    Object.assign(reporterOptions, {isSauseLabRun: true})
+    Object.assign(reporterOptions, {isSauseLabRun: true});
 
-    addSauceLabAttributes(reporterOptions, testItem, sessionId)
+    addSauceLabAttributes(reporterOptions, testItem, sessionId);
 
-    expect(testItem.attributes.length).toEqual(1)
+    expect(testItem.attributes.length).toEqual(1);
     expect(testItem.attributes).toEqual([{key: "SLID", value: sessionId}])
   });
 
@@ -121,13 +123,13 @@ describe("#addSauceLabAttributes",  () => {
     const testItem = new StartTestItem("name", TYPE.STEP);
     const sauceLabOptions =  {
       enabled: true
-    }
+    };
     const reporterOptions = getDefaultOptions();
     Object.assign(reporterOptions, {sauceLabOptions});
 
-    addSauceLabAttributes(reporterOptions, testItem, sessionId)
+    addSauceLabAttributes(reporterOptions, testItem, sessionId);
 
-    expect(testItem.attributes.length).toEqual(1)
+    expect(testItem.attributes.length).toEqual(1);
     expect(testItem.attributes).toEqual([{key: "SLID", value: sessionId}])
   });
 
@@ -136,13 +138,13 @@ describe("#addSauceLabAttributes",  () => {
     const sauceLabOptions =  {
       enabled: true,
       sldc: "foo"
-    }
+    };
     const reporterOptions = getDefaultOptions();
     Object.assign(reporterOptions, {sauceLabOptions});
 
-    addSauceLabAttributes(reporterOptions, testItem, sessionId)
+    addSauceLabAttributes(reporterOptions, testItem, sessionId);
 
-    expect(testItem.attributes.length).toEqual(2)
+    expect(testItem.attributes.length).toEqual(2);
     expect(testItem.attributes).toEqual([{key: "SLID", value: sessionId}, {key: "SLDC", value: "foo"}])
   });
 
@@ -150,8 +152,22 @@ describe("#addSauceLabAttributes",  () => {
     const testItem = new StartTestItem("name", TYPE.STEP);
     const reporterOptions = getDefaultOptions();
 
-    addSauceLabAttributes(reporterOptions, testItem, sessionId)
+    addSauceLabAttributes(reporterOptions, testItem, sessionId);
 
     expect(testItem.attributes.length).toEqual(0)
+  });
+});
+
+describe("#addCodeRef",  () => {
+  test("should add code reference to the test item", () => {
+    const testStartObj = new StartTestItem("foo", TYPE.TEST);
+    addCodeRef("C:\\webdriver.io\\tests\\example.spec.js", testStartObj);
+    expect(testStartObj.codeRef).toEqual(`C:\\webdriver.io\\tests\\example.spec.js${path.sep}foo`);
+  });
+
+  test("should not add code reference if missing", () => {
+    const testStartObj = new StartTestItem("foo", TYPE.TEST);
+    addCodeRef(undefined, testStartObj);
+    expect(testStartObj.codeRef).toBeUndefined();
   });
 });

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -14,7 +14,8 @@ import {
   isScreenshotCommand,
   limit,
   promiseErrorHandler,
-  sendToReporter
+  sendToReporter,
+  addCodeRef
 } from "./utils";
 
 const log = logger("wdio-reportportal-reporter");
@@ -82,7 +83,7 @@ class ReportPortalReporter extends Reporter {
   private sanitizedCapabilities: string;
   private sessionId: string;
   private rpPromisesCompleted = true;
-  private specFile: string;
+  private specFilePath: string;
   private featureStatus: STATUS;
   private featureName: string;
   private currentTestAttributes: Attribute[] = [];
@@ -176,7 +177,7 @@ class ReportPortalReporter extends Reporter {
     }
     const suite = this.storage.getCurrentSuite();
     const testStartObj = new StartTestItem(test.title, type);
-    testStartObj.codeRef = this.specFile;
+    addCodeRef(this.specFilePath, testStartObj);
 
     if (this.options.cucumberNestedSteps) {
       testStartObj.hasStats = false;
@@ -258,7 +259,7 @@ class ReportPortalReporter extends Reporter {
     this.sessionId = runner.sessionId;
     this.client = client || new ReportPortalClient(this.options.reportPortalClientConfig);
     this.launchId = process.env.RP_LAUNCH_ID;
-    this.specFile = runner.specs[0];
+    this.specFilePath = runner.specs[0];
     const startLaunchObj = {
       attributes: this.options.reportPortalClientConfig.attributes,
       description: this.options.reportPortalClientConfig.description,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import logger from "@wdio/logger";
 import validator from "validator";
+import * as path from "path";
 import {StartTestItem} from "./entities";
 import ReporterOptions from "./ReporterOptions";
 
@@ -103,6 +104,12 @@ export const addSauceLabAttributes = (options: ReporterOptions, testItem: StartT
 export const addDescription = (description: string, testItem: StartTestItem) => {
   if (description) {
     testItem.description = description;
+  }
+};
+
+export const addCodeRef = (basePath: string, testItem: StartTestItem) => {
+  if (basePath) {
+    testItem.codeRef = `${basePath}${path.sep}${testItem.name}`;
   }
 };
 


### PR DESCRIPTION
## Proposed changes
Use test item name to build code reference to ensure that the `testCaseId` is generated correctly on the RP side ([docs link](https://reportportal.io/docs/Test-case-ID%3Ewhat-is-it-test-case-id)).
This improvement helps to ensure uniqueness for automated `testCaseId` generation.