### PR TITLE
add-message-property-to-send-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const reporter = require('wdio-reportportal-reporter')
     * `name` (*string*)– file name.
     * `content` (*string*) – attachment content
     * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
+    * `message` (*string*)– log message content.
 * `reporter.sendLogToTest(test, level, message)` - send log to specific test.
     * `test` (*object*) - test object from `afterTest\afterStep` wdio hook
     * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
@@ -90,6 +91,8 @@ const reporter = require('wdio-reportportal-reporter')
     * `name` (*string*)– file name.
     * `content` (*string*) – attachment content
     * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
+    * `message` (*string*)– log message content.
+
 
 Pay attention: `sendLog`\\`sendFile` sends log to **current running test item**. It means if you send log without active test(e.g from hooks or on suite level) it will not be reported Report Portal UI.
 

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -36,16 +36,16 @@ class ReportPortalReporter extends Reporter {
     sendToReporter(EVENTS.RP_LOG, {level, message});
   }
 
-  public static sendFile(level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png") {
-    sendToReporter(EVENTS.RP_FILE, {level, name, content, type});
+  public static sendFile(level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png", message = "") {
+    sendToReporter(EVENTS.RP_FILE, {level, name, content, type, message});
   }
 
   public static sendLogToTest(test: any, level: LEVEL | keyof typeof LEVEL, message: any) {
     sendToReporter(EVENTS.RP_TEST_LOG, {test, level, message});
   }
 
-  public static sendFileToTest(test: any, level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png") {
-    sendToReporter(EVENTS.RP_TEST_FILE, {test, level, name, content, type});
+  public static sendFileToTest(test: any, level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png", message = "") {
+    sendToReporter(EVENTS.RP_TEST_FILE, {test, level, name, content, type, message});
   }
 
   public static finishTestManually(test: any) {
@@ -318,6 +318,7 @@ class ReportPortalReporter extends Reporter {
           content: command.result.value,
           level: screenshotsLogLevel,
           name: "screenshot.png",
+          message: "screenshot"
         };
         this.sendFile(obj);
       }
@@ -381,14 +382,14 @@ class ReportPortalReporter extends Reporter {
     promiseErrorHandler(promise);
   }
 
-  private sendFile({level, name, content, type = "image/png"}) {
+  private sendFile({level, name, content, type = "image/png", message = ""}) {
     const testItem = this.storage.getCurrentTest();
     if (!testItem) {
       log.warn(`Can not send file to test. There is no running tests`);
       return;
     }
 
-    const {promise} = this.client.sendLog(testItem.id, {level}, {name, content, type});
+    const {promise} = this.client.sendLog(testItem.id, {level}, {name, content, type, message});
     promiseErrorHandler(promise);
   }
 
@@ -416,7 +417,7 @@ class ReportPortalReporter extends Reporter {
     promiseErrorHandler(promise);
   }
 
-  private async sendFileToTest({test, level, name, content, type = "image/png"}) {
+  private async sendFileToTest({test, level, name, content, type = "image/png", message = ""}) {
     const testObj = this.storage.getStartedTests().reverse().find((startedTest) => {
       return startedTest.wdioEntity.title === test.title;
     });
@@ -430,7 +431,7 @@ class ReportPortalReporter extends Reporter {
       itemUuid: rs.id,
       launchUuid: this.launchId,
       level,
-      message: "",
+      message,
       time: this.now(),
     };
     // to avoid https://github.com/BorisOsipov/wdio-reportportal-reporter/issues/42#issuecomment-456573592


### PR DESCRIPTION
## Proposed changes
Adding attachment does not support custom messages, and attachment has no label in the report. 

Updating API to add a message for the attachments for better logs visibility in the reporter