### PR TITLE
Fix onRunnerStart function signature

### DIFF
--- a/lib/__tests__/startLaunch.spec.ts
+++ b/lib/__tests__/startLaunch.spec.ts
@@ -14,10 +14,11 @@ describe("startLaunch", () => {
   test("should startLaunch with default mode", () => {
     const options = getDefaultOptions();
     const reporter = new Reporter(options);
-    const client = new RPClientMock();
     process.env.RP_LAUNCH_ID = REAL_LAUNCH_ID;
 
-    reporter.onRunnerStart(runnerStat, client);
+    jest.spyOn(reporter, 'getReportPortalClient').mockImplementation(() =>  new RPClientMock());
+
+    reporter.onRunnerStart(runnerStat);
 
     expect(reporter.tempLaunchId).toEqual("startLaunch");
     expect(reporter.launchId).toEqual(REAL_LAUNCH_ID);
@@ -40,10 +41,11 @@ describe("startLaunch", () => {
     options.reportPortalClientConfig.attributes = [new Attribute("foo", "bar")];
     options.reportPortalClientConfig.description = "bar";
     const reporter = new Reporter(options);
-    const client = new RPClientMock();
     process.env.RP_LAUNCH_ID = REAL_LAUNCH_ID;
+    process.env.RP_MOCK_CLIENT = "true";
 
-    reporter.onRunnerStart(runnerStat, client);
+    jest.spyOn(reporter, 'getReportPortalClient').mockImplementation(() =>  new RPClientMock());
+    reporter.onRunnerStart(runnerStat);
 
     expect(reporter.tempLaunchId).toEqual("startLaunch");
     expect(reporter.launchId).toEqual(REAL_LAUNCH_ID);

--- a/lib/__tests__/startLaunch.spec.ts
+++ b/lib/__tests__/startLaunch.spec.ts
@@ -42,7 +42,6 @@ describe("startLaunch", () => {
     options.reportPortalClientConfig.description = "bar";
     const reporter = new Reporter(options);
     process.env.RP_LAUNCH_ID = REAL_LAUNCH_ID;
-    process.env.RP_MOCK_CLIENT = "true";
 
     jest.spyOn(reporter, 'getReportPortalClient').mockImplementation(() =>  new RPClientMock());
     reporter.onRunnerStart(runnerStat);

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -258,15 +258,14 @@ class ReportPortalReporter extends Reporter {
     this.currentTestAttributes = [];
   }
 
-  // @ts-ignore
-  onRunnerStart(runner, client: ReportPortalClient) {
+  onRunnerStart(runner) {
     log.debug(`Runner start`);
     this.rpPromisesCompleted = false;
     this.isMultiremote = runner.isMultiremote;
     this.sanitizedCapabilities = runner.sanitizedCapabilities;
     this.sessionId = runner.sessionId;
     this.isCucumberFramework = runner.config.framework === 'cucumber'
-    this.client = client || new ReportPortalClient(this.options.reportPortalClientConfig);
+    this.client = this.getReportPortalClient();
     this.launchId = process.env.RP_LAUNCH_ID;
     this.specFilePath = runner.specs[0] || "";
     const startLaunchObj = {
@@ -345,6 +344,10 @@ class ReportPortalReporter extends Reporter {
       }
       this.testFinished(hook, STATUS.FAILED);
     }
+  }
+
+  private getReportPortalClient(): ReportPortalClient{
+    return new ReportPortalClient(this.options.reportPortalClientConfig);
   }
 
   private addAttribute(attribute: Attribute) {


### PR DESCRIPTION
Fix for error:
Property 'onRunnerStart' in type 'ReportPortalReporter' is not assignable to the same property in base type 'WDIOReporter'.
  Type '(runner: any, client: any) => void' is not assignable to type '(runnerStats: RunnerStats) => void'.
   onRunnerStart(runner: any, client: ReportPortalClient): void;

Since the client passed to onRunnerStart only for the test purpose, removing the variable from the function signature and mocking the client creation in tests 