### PR TITLE
Acquire specFilePath from suite there maybe multiple specs per runner

### DIFF
--- a/lib/__tests__/fixtures/events.ts
+++ b/lib/__tests__/fixtures/events.ts
@@ -4,7 +4,8 @@ export const suiteStartEvent = () => ({
   uid: "FooBarSuite",
   cid: "0-0",
   title: "foo",
-  runner: {"0-0": {}}
+  runner: {"0-0": {}},
+  file: "C:/work/home/spec.ts"
 });
 
 export const suiteEndEvent = () => ({

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -113,7 +113,7 @@ class ReportPortalReporter extends Reporter {
       addSauceLabAttributes(this.reporterOptions, suiteStartObj, this.sessionId);
     }
     if (isCucumberScenario) {
-      suiteStartObj.codeRef = getRelativePath(this.\) + ':' + suite.uid.replace(suite.title, '').trim();
+      suiteStartObj.codeRef = getRelativePath(this.specFilePath) + ':' + suite.uid.replace(suite.title, '').trim();
     }
     if (this.reporterOptions.cucumberNestedSteps && this.reporterOptions.autoAttachCucumberFeatureToScenario) {
       switch (suite.type) {

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -103,7 +103,7 @@ class ReportPortalReporter extends Reporter {
 
   onSuiteStart(suite) {
     log.debug(`Start suite ${suite.title} ${suite.uid}`);
-
+    this.specFilePath = suite.file || "";
     const isCucumberFeature = suite.type === CUCUMBER_TYPE.FEATURE;
     const isCucumberScenario = suite.type === CUCUMBER_TYPE.SCENARIO;
     const suiteStartObj = this.reporterOptions.cucumberNestedSteps ?
@@ -113,7 +113,7 @@ class ReportPortalReporter extends Reporter {
       addSauceLabAttributes(this.reporterOptions, suiteStartObj, this.sessionId);
     }
     if (isCucumberScenario) {
-      suiteStartObj.codeRef = getRelativePath(this.specFilePath) + ':' + suite.uid.replace(suite.title, '').trim();
+      suiteStartObj.codeRef = getRelativePath(this.\) + ':' + suite.uid.replace(suite.title, '').trim();
     }
     if (this.reporterOptions.cucumberNestedSteps && this.reporterOptions.autoAttachCucumberFeatureToScenario) {
       switch (suite.type) {
@@ -270,7 +270,7 @@ class ReportPortalReporter extends Reporter {
     this.isCucumberFramework = runner.config.framework === 'cucumber'
     this.client = this.getReportPortalClient();
     this.launchId = process.env.RP_LAUNCH_ID;
-    this.specFilePath = runner.specs[0] || "";
+    
     const startLaunchObj = {
       attributes: this.reporterOptions.reportPortalClientConfig.attributes,
       description: this.reporterOptions.reportPortalClientConfig.description,

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -103,7 +103,7 @@ class ReportPortalReporter extends Reporter {
 
   onSuiteStart(suite) {
     log.debug(`Start suite ${suite.title} ${suite.uid}`);
-    this.specFilePath = suite.file || "";
+    this.specFilePath = suite.file ? suite.file : this.specFilePath;
     const isCucumberFeature = suite.type === CUCUMBER_TYPE.FEATURE;
     const isCucumberScenario = suite.type === CUCUMBER_TYPE.SCENARIO;
     const suiteStartObj = this.reporterOptions.cucumberNestedSteps ?
@@ -270,6 +270,7 @@ class ReportPortalReporter extends Reporter {
     this.isCucumberFramework = runner.config.framework === 'cucumber'
     this.client = this.getReportPortalClient();
     this.launchId = process.env.RP_LAUNCH_ID;
+    this.specFilePath = runner.specs[0] || "";
     const startLaunchObj = {
       attributes: this.reporterOptions.reportPortalClientConfig.attributes,
       description: this.reporterOptions.reportPortalClientConfig.description,

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -103,7 +103,7 @@ class ReportPortalReporter extends Reporter {
 
   onSuiteStart(suite) {
     log.debug(`Start suite ${suite.title} ${suite.uid}`);
-    this.specFilePath = suite.file ? suite.file : this.specFilePath;
+    this.specFilePath = suite.file;
     const isCucumberFeature = suite.type === CUCUMBER_TYPE.FEATURE;
     const isCucumberScenario = suite.type === CUCUMBER_TYPE.SCENARIO;
     const suiteStartObj = this.reporterOptions.cucumberNestedSteps ?
@@ -270,7 +270,6 @@ class ReportPortalReporter extends Reporter {
     this.isCucumberFramework = runner.config.framework === 'cucumber'
     this.client = this.getReportPortalClient();
     this.launchId = process.env.RP_LAUNCH_ID;
-    this.specFilePath = runner.specs[0] || "";
     const startLaunchObj = {
       attributes: this.reporterOptions.reportPortalClientConfig.attributes,
       description: this.reporterOptions.reportPortalClientConfig.description,

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -270,7 +270,6 @@ class ReportPortalReporter extends Reporter {
     this.isCucumberFramework = runner.config.framework === 'cucumber'
     this.client = this.getReportPortalClient();
     this.launchId = process.env.RP_LAUNCH_ID;
-    
     const startLaunchObj = {
       attributes: this.reporterOptions.reportPortalClientConfig.attributes,
       description: this.reporterOptions.reportPortalClientConfig.description,


### PR DESCRIPTION
WDIO allows for multiple Cucumber features or specs to be grouped on a single runner, the assumption that the first item in `runner.specs` is the `specFilePath` is incorrect.

## Proposed changes
Instead of finding `this.specFilePath` once we find it every time we start a new suite.

