### PR TITLE
Add method to add attribute to current suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 WDIO Report Portal Reporter
 ====================
+
 [![Greenkeeper badge](https://badges.greenkeeper.io/BorisOsipov/wdio-reportportal-reporter.svg)](https://greenkeeper.io/)
 
 ![npm](https://img.shields.io/npm/v/wdio-reportportal-reporter)
 ![npm](https://img.shields.io/npm/dm/wdio-reportportal-reporter)
-> A WebdriverIO reporter plugin to report results to Report Portal(http://reportportal.io/).
+> A WebdriverIO reporter plugin to report results to Report Portal(<http://reportportal.io/>).
 
 ## Installation
+
 The easiest way is to keep `wdio-reportportal-reporter` and `wdio-reportportal-service` as a devDependency in your `package.json`.
+
 ```json
 {
   "devDependencies": {
@@ -16,9 +19,13 @@ The easiest way is to keep `wdio-reportportal-reporter` and `wdio-reportportal-s
   }
 }
 ```
+
 Instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted.html).
+
 ## Configuration
+
 Configure the output directory in your wdio.conf.js file:
+
 ```js
 const reportportal = require('wdio-reportportal-reporter');
 const RpService = require("wdio-reportportal-service");
@@ -72,40 +79,46 @@ exports.config = {
 # Additional API
 
 Api methods can be accessed using:
+
 ```js
 const reporter = require('wdio-reportportal-reporter')
 ```
+
 ### Methods description
-* `reporter.addAttribute({key, value}) ` – add an attribute to current test.
+
+* `reporter.addAttribute({key, value})` – add an attribute to current test.
   * `key` (*string*, optional) -  attribute key. It must be non-empty string.
   * `value` (*string*, required)–  attribute value. It must be non-empty string.
-* `reporter.sendLog(level, message) ` – send log to current suite\test item.
-    * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
-    * `message` (*string*)– log message content.
+* `reporter.addAttributeToCurrentSuite({key, value})` - add an attribute to current suite.
+  * `key` (*string*, optional) -  attribute key. It must be non-empty string.
+  * `value` (*string*, required)–  attribute value. It must be non-empty string.
+* `reporter.sendLog(level, message)` – send log to current suite\test item.
+  * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
+  * `message` (*string*)– log message content.
 * `reporter.sendFile(level, name, content, [type])` – send file to current suite\test item.
-    * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
-    * `name` (*string*)– file name.
-    * `content` (*string*) – attachment content
-    * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
-    * `message` (*string*)– log message content.
+  * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
+  * `name` (*string*)– file name.
+  * `content` (*string*) – attachment content
+  * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
+  * `message` (*string*)– log message content.
 * `reporter.sendLogToTest(test, level, message)` - send log to specific test.
-    * `test` (*object*) - test object from `afterTest\afterStep` wdio hook
-    * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
-    * `message` (*string*)– log message content.
+  * `test` (*object*) - test object from `afterTest\afterStep` wdio hook
+  * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
+  * `message` (*string*)– log message content.
 * `reporter.sendFileToTest(test, level, name, content, [type])` – send file to to specific test.
-    * `test` (*object*) - test object from `afterTest\afterStep` wdio hook
-    * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
-    * `name` (*string*)– file name.
-    * `content` (*string*) – attachment content
-    * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
-    * `message` (*string*)– log message content.
-
+  * `test` (*object*) - test object from `afterTest\afterStep` wdio hook
+  * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
+  * `name` (*string*)– file name.
+  * `content` (*string*) – attachment content
+  * `type` (*string*, optional) – attachment MIME-type, `image/png` by default
+  * `message` (*string*)– log message content.
 
 Pay attention: `sendLog`\\`sendFile` sends log to **current running test item**. It means if you send log without active test(e.g from hooks or on suite level) it will not be reported Report Portal UI.
 
 Methods `sendLogToTest`\\`sendFileToTest` are useful when you need to send screenshots or logs to the failed test item from wdio afterTest hook.
 
 Mocha example:
+
 ```js
 const reportportal = require('wdio-reportportal-reporter');
 const path = require('path');
@@ -125,6 +138,7 @@ exports.config = {
 ```
 
 Jasmine example:
+
 ```js
 const reportportal = require('wdio-reportportal-reporter');
 const path = require('path');
@@ -146,6 +160,7 @@ exports.config = {
 ```
 
 WDIO Cucumber "5.14.3+" Example:
+
 ```js
 const reportportal = require('wdio-reportportal-reporter');
 
@@ -167,6 +182,7 @@ exports.config = {
 ```
 
 ## Getting link to Report Portal UI launch page
+
 ```js
 const RpService = require("wdio-reportportal-service");
 ...
@@ -176,6 +192,7 @@ const RpService = require("wdio-reportportal-service");
     }
 ...
 ```
+
 or more complicated way
 
 ```js
@@ -197,8 +214,8 @@ If you want report test to existing active launch you may pass it to reporter by
 You are responsible for finishing launch as well as starting such launch.
 
 ```sh
-$ export REPORT_PORTAL_LAUNCH_ID=SomeLaunchId
-$ npm run wdio
+export REPORT_PORTAL_LAUNCH_ID=SomeLaunchId
+npm run wdio
 ```
 
 ## License

--- a/lib/__tests__/endSuite.spec.ts
+++ b/lib/__tests__/endSuite.spec.ts
@@ -1,5 +1,6 @@
 import {WDIO_TEST_STATUS, CUCUMBER_TYPE, STATUS} from "../constants";
 import {suiteEndEvent, suiteStartEvent} from "./fixtures/events";
+import {singleAttribute} from "./fixtures/attributes"
 import {getDefaultOptions, RPClientMock} from "./reportportal-client.mock";
 
 const Reporter = require("../../build/reporter");
@@ -21,9 +22,33 @@ describe("endSuite", () => {
     expect(reporter.client.finishTestItem).toBeCalledTimes(1);
     expect(reporter.client.finishTestItem).toBeCalledWith(
       id,
-      {status: STATUS.PASSED},
+      {
+        status: STATUS.PASSED,
+        attributes: []
+      },
+
     );
   });
+
+
+
+  test("should set given attributes to endSuite", () => {
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.addAttributeToSuite(singleAttribute)
+    reporter.onSuiteEnd(suiteEndEvent());
+
+    expect(reporter.client.finishTestItem).toBeCalledTimes(1);
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {
+        status: STATUS.PASSED,
+        attributes: [
+        singleAttribute
+      ]
+      },
+
+    );
+  })
 
 
   test("should set status as failing if there are failed tests", () => {
@@ -43,7 +68,34 @@ describe("endSuite", () => {
 
     expect(reporter.client.finishTestItem).toBeCalledWith(
       id,
-      {status: STATUS.FAILED},
+      {
+        status: STATUS.FAILED,
+        attributes: []
+      },
+    );
+  });
+
+  test("should set status as passed if all tests passed", () => {
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.onSuiteEnd(Object.assign(
+      suiteEndEvent(),
+      {
+        tests: [
+          {
+            state: WDIO_TEST_STATUS.PASSED,
+          },
+          {
+            state: WDIO_TEST_STATUS.PASSED,
+          },
+        ]
+      }));
+
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {
+        status: STATUS.PASSED,
+        attributes: []
+      },
     );
   });
 
@@ -66,7 +118,10 @@ describe("endSuite", () => {
 
     expect(reporter.client.finishTestItem).toBeCalledWith(
       id,
-      {status: STATUS.PASSED},
+      {
+        status: STATUS.PASSED,
+        attributes: []
+      },
     );
   });
 
@@ -89,7 +144,10 @@ describe("endSuite", () => {
 
     expect(reporter.client.finishTestItem).toBeCalledWith(
       id,
-      {status: STATUS.FAILED},
+      {
+        status: STATUS.FAILED,
+        attributes: []
+      },
     );
   });
 });

--- a/lib/__tests__/fixtures/attributes.ts
+++ b/lib/__tests__/fixtures/attributes.ts
@@ -1,0 +1,4 @@
+export const singleAttribute = {
+  key: "os",
+  valie: "linux"
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,7 @@ export enum EVENTS {
   RP_TEST_FILE = "rp:failedFile",
   RP_TEST_RETRY = "rp:testRetry",
   RP_TEST_ATTRIBUTES = "rp:testAttributes",
+  RP_SUITE_ATTRIBUTES = "rp:SuiteAttributes",
 }
 
 export enum STATUS {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -101,6 +101,7 @@ export const addDescription = (description: string, testItem: StartTestItem) => 
   }
 };
 
+
 export const parseTags = (text: string): string[] => ("" + text).match(TAGS_PATTERN) || [];
 
 export const isScreenshotCommand = (command: any) => {


### PR DESCRIPTION
## Proposed changes
I needed to add attributes on suite level. This PR extends the public API with `addAttributeToSuite` and makes it possible to collect attributes during tests and add them to suite on suite end.

