### PR TITLE
Add description to suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ const reporter = require('wdio-reportportal-reporter')
   * `key` (*string*, optional) -  attribute key. It must be non-empty string.
   * `value` (*string*, required)–  attribute value. It must be non-empty string.
 * `reporter.addDescriptionToCurrentSuite(description)` - add some string to current suite.
-  * `description` (*string*) - description content
+  * `description` (*string*) - description content. Text can be formatted with markdown.
 * `reporter.addDescriptionToAllSuites(description)` - add some string to all upcoming suites. (Use it in before all hook, so every suite gets the same description)
-  * `description` (*string*) - description content
+  * `description` (*string*) - description content. Text can be formatted with markdown.
 * `reporter.sendLog(level, message)` – send log to current suite\test item.
   * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
   * `message` (*string*)– log message content.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ const reporter = require('wdio-reportportal-reporter')
 * `reporter.addAttributeToCurrentSuite({key, value})` - add an attribute to current suite.
   * `key` (*string*, optional) -  attribute key. It must be non-empty string.
   * `value` (*string*, required)–  attribute value. It must be non-empty string.
+* `reporter.addDescriptionToCurrentSuite(description)` - add some string to current suite.
+  * `description` (*string*) - description content
+* `reporter.addDescriptionToAllSuites(description)` - add some string to all upcoming suites. (Use it in before all hook, so every suite gets the same description)
+  * `description` (*string*) - description content
 * `reporter.sendLog(level, message)` – send log to current suite\test item.
   * `level` (*string*) - log level. Values ['trace', 'debug', 'info', 'warn', 'error'].
   * `message` (*string*)– log message content.

--- a/lib/__tests__/endSuite.spec.ts
+++ b/lib/__tests__/endSuite.spec.ts
@@ -24,8 +24,10 @@ describe("endSuite", () => {
       id,
       {
         status: STATUS.PASSED,
-        attributes: []
+        attributes: [],
+        description: ""
       },
+
 
     );
   });
@@ -43,8 +45,25 @@ describe("endSuite", () => {
       {
         status: STATUS.PASSED,
         attributes: [
-        singleAttribute
-      ]
+          singleAttribute
+        ],
+        description: ""
+      },
+
+    );
+  })
+
+  test("should set given description", () => {
+    const {id} = reporter.storage.getCurrentSuite();
+    reporter.addDescriptionToCurrentSuite('new description')
+    reporter.onSuiteEnd(suiteEndEvent());
+    expect(reporter.client.finishTestItem).toBeCalledTimes(1);
+    expect(reporter.client.finishTestItem).toBeCalledWith(
+      id,
+      {
+        status: STATUS.PASSED,
+        attributes: [],
+        description: "new description"
       },
 
     );
@@ -70,7 +89,8 @@ describe("endSuite", () => {
       id,
       {
         status: STATUS.FAILED,
-        attributes: []
+        attributes: [],
+        description: ""
       },
     );
   });
@@ -94,7 +114,8 @@ describe("endSuite", () => {
       id,
       {
         status: STATUS.PASSED,
-        attributes: []
+        attributes: [],
+        description: ""
       },
     );
   });
@@ -120,7 +141,8 @@ describe("endSuite", () => {
       id,
       {
         status: STATUS.PASSED,
-        attributes: []
+        attributes: [],
+        description: ""
       },
     );
   });
@@ -146,7 +168,8 @@ describe("endSuite", () => {
       id,
       {
         status: STATUS.FAILED,
-        attributes: []
+        attributes: [],
+        description: ""
       },
     );
   });

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -19,7 +19,7 @@ describe("startSuite", () => {
 
     expect(reporter.client.startTestItem).toBeCalledTimes(1);
     expect(reporter.client.startTestItem).toBeCalledWith(
-      {description: undefined, attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      {description: "", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
       reporter.tempLaunchId,
       null,
     );
@@ -30,7 +30,7 @@ describe("startSuite", () => {
 
     expect(reporter.client.startTestItem).toBeCalledTimes(1);
     expect(reporter.client.startTestItem).toBeCalledWith(
-      {description: undefined, attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      {description: "", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
       reporter.tempLaunchId,
       null,
     );
@@ -43,7 +43,7 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toBeCalledTimes(2);
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       1,
-      {description: undefined, attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      {description: "", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
       reporter.tempLaunchId,
       null,
     );
@@ -51,7 +51,7 @@ describe("startSuite", () => {
     const {id} = reporter.storage.getCurrentSuite();
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       2,
-      {description: undefined, attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      {description: "", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
       reporter.tempLaunchId,
       id,
     );
@@ -65,7 +65,7 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toBeCalledTimes(2);
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       1,
-      {description: undefined, attributes: [], name: "foo", type: TYPE.TEST, retry: false},
+      {description: "", attributes: [], name: "foo", type: TYPE.TEST, retry: false},
       reporter.tempLaunchId,
       null,
     );
@@ -74,7 +74,7 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       2,
       {
-        description: undefined,
+        description: "",
         attributes: [],
         name: "foo",
         type: TYPE.STEP,
@@ -100,12 +100,48 @@ describe("startSuite", () => {
         type: TYPE.STEP,
         retry: false,
         attributes: [{key: CUCUMBER_TYPE.FEATURE, value: "foo"}],
-        codeRef: "C:/work/home/spec.ts:FooBarSuite"
+        codeRef: "C:/work/home/spec.ts:FooBarSuite",
+        description: ""
       },
       reporter.tempLaunchId,
       id,
     );
   });
+
+  test("should set description for current suite", () => {
+
+    reporter.addDescriptionToCurrentSuite('new description')
+    reporter.onSuiteStart(suiteStartEvent());
+
+    expect(reporter.client.startTestItem).toBeCalledTimes(1);
+    expect(reporter.client.startTestItem).toBeCalledWith(
+      {description: "new description", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      reporter.tempLaunchId,
+      null,
+    );
+  })
+
+  test("should set description for all suite", () => {
+
+    reporter.addDescriptionToAllSuites('new description')
+    reporter.onSuiteStart(suiteStartEvent());
+
+    expect(reporter.client.startTestItem).toBeCalledTimes(1);
+    expect(reporter.client.startTestItem).toBeCalledWith(
+      {description: "new description", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      reporter.tempLaunchId,
+      null,
+    );
+
+    reporter.onSuiteStart(suiteStartEvent());
+
+    expect(reporter.client.startTestItem).toBeCalledTimes(2);
+    expect(reporter.client.startTestItem).toBeCalledWith(
+      {description: "new description", attributes: [], name: "foo", type: TYPE.SUITE, retry: false},
+      reporter.tempLaunchId,
+      null,
+    );
+  })
 
   test("should add sldc/slid to cucumber test", () => {
     const sauceLabOptions = {
@@ -121,7 +157,7 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       1,
       {
-        description: undefined,
+        description: "",
         attributes: [{key: "SLID", value: "bar"}, {key: "SLDC", value: "foo"}],
         name: "foo",
         type: TYPE.TEST,
@@ -135,7 +171,7 @@ describe("startSuite", () => {
     expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
       2,
       {
-        description: undefined,
+        description: "",
         attributes: [],
         name: "foo",
         type: TYPE.STEP,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,6 +6,8 @@ export enum EVENTS {
   RP_TEST_RETRY = "rp:testRetry",
   RP_TEST_ATTRIBUTES = "rp:testAttributes",
   RP_SUITE_ATTRIBUTES = "rp:SuiteAttributes",
+  RP_SUITE_ADD_DESCRIPTION = "rp:SuiteDescription",
+  RP_ALL_SUITE_ADD_DESCRIPTION = "rp:AllSuiteDescription"
 }
 
 export enum STATUS {

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -162,7 +162,6 @@ class ReportPortalReporter extends Reporter {
       suiteStartObj.addTags();
     }
 
-    log.debug(`ONSuiteStart - description: ${this.currentSuiteDescription}`)
     suiteStartObj.description = [...this.suitesDescription, ...this.currentSuiteDescription].join('\n')
     const {tempId, promise} = this.client.startTestItem(
       suiteStartObj,
@@ -289,7 +288,7 @@ class ReportPortalReporter extends Reporter {
     log.debug(`Runner start`);
     this.rpPromisesCompleted = false;
     this.isMultiremote = runner.isMultiremote;
-    this.suitesDescription.push(runner.sanitizedCapabilities)
+    this.sanitizedCapabilities = runner.sanitizedCapabilities;
     this.sessionId = runner.sessionId;
     this.isCucumberFramework = runner.config.framework === 'cucumber'
     this.client = this.getReportPortalClient();


### PR DESCRIPTION
## Add description to all suites and current suite
Needed some information in the suites description, like link to browserstack session or links to logfiles.

There are two new API endpoints to add description to suites.
1. `addDescriptionToCurrentSuite` adds the description to the current running suite
2. `addDescriptionToAllSuites` Adds the description to all suites that are running or not finished.

I needed to add information in before all hook without loosing this information if there were more suites in one spec.
So there is now a class property which gets assigned in the `onRunnerStart` hook and are added to the description for each suite.

For adding text to the description for the current suite there is another class property which gets dumped in the `onSuiteEnd` hook.

The description gets added to the existing description.

Fixed: #167 
