### PR TITLE
[Feature] Add `throwOnReportingError` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const conf = {
   cucumberNestedSteps: false, // report cucumber steps as Report Portal steps
   autoAttachCucumberFeatureToScenario: false, // requires cucumberNestedSteps to be true for use
   sanitizeErrorMessages: true, // strip color ascii characters from error stacktrace
+  throwOnReportingFailure: true, // throw an exception if some reporting operation fails
   sauceLabOptions : {
     enabled: true, // automatically add SauseLab ID to rp tags.
     sldc: "US" // automatically add SauseLab region to rp tags.

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -31,5 +31,6 @@ export default class ReporterOptions {
   public cucumberNestedSteps = false;
   public autoAttachCucumberFeatureToScenario = false;
   public sanitizeErrorMessages = true;
+  public throwOnReportingFailure = true;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, attributes: [Attribute], description: ""};
 }

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -34,33 +34,67 @@ class ReportPortalReporter extends Reporter {
   }
 
   public static sendLog(level: LEVEL | keyof typeof LEVEL, message: any) {
-    sendToReporter(EVENTS.RP_LOG, {level, message});
+    try {
+      sendToReporter(EVENTS.RP_LOG, {level, message});
+    } catch (e) {
+      log.error("An error occured when sending log");
+      log.error(e);
+    }
   }
 
   public static sendFile(level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png", message = "") {
-    sendToReporter(EVENTS.RP_FILE, {level, name, content, type, message});
+    try {
+      sendToReporter(EVENTS.RP_FILE, {level, name, content, type, message});
+    } catch (e) {
+      log.error("An error occured when sending file");
+      log.error(e);
+    }
   }
 
   public static sendLogToTest(test: any, level: LEVEL | keyof typeof LEVEL, message: any) {
-    sendToReporter(EVENTS.RP_TEST_LOG, {test, level, message});
+    try {
+      sendToReporter(EVENTS.RP_TEST_LOG, {test, level, message});
+    } catch (e) {
+      log.error("An error occured when sending log to test");
+      log.error(e);
+    }
   }
 
   public static sendFileToTest(test: any, level: LEVEL | keyof typeof LEVEL, name: string, content: any, type = "image/png", message = "") {
-    sendToReporter(EVENTS.RP_TEST_FILE, {test, level, name, content, type, message});
+    try {
+      sendToReporter(EVENTS.RP_TEST_FILE, {test, level, name, content, type, message});
+    } catch (e) {
+      log.error("An error occured when sending file to test");
+      log.error(e);
+    }
   }
 
   public static finishTestManually(test: any) {
-    sendToReporter(EVENTS.RP_TEST_RETRY, {test});
+    try {
+      sendToReporter(EVENTS.RP_TEST_RETRY, {test});
+    } catch (e) {
+      log.error("An error occured when finishing test manually");
+      log.error(e);
+    }
   }
 
   public static addDescriptionToCurrentSuite(description: string) {
-    sendToReporter(EVENTS.RP_SUITE_ADD_DESCRIPTION, description)
+    try {
+      sendToReporter(EVENTS.RP_SUITE_ADD_DESCRIPTION, description)
+    } catch (e) {
+      log.error("An error occured when adding description to current suite");
+      log.error(e);
+    }
   }
 
   public static addDescriptionToAllSuites(description: string) {
-    sendToReporter(EVENTS.RP_ALL_SUITE_ADD_DESCRIPTION, description)
+    try {
+      sendToReporter(EVENTS.RP_ALL_SUITE_ADD_DESCRIPTION, description)
+    } catch (e) {
+      log.error("An error occured when adding description to all suites")
+      log.error(e)
+    }
   }
-
 
   private static getValidatedAttribute(attribute: Attribute): Attribute {
     if (!attribute) {
@@ -85,11 +119,21 @@ class ReportPortalReporter extends Reporter {
   }
 
   public static addAttribute(attribute: Attribute) {
-    sendToReporter(EVENTS.RP_TEST_ATTRIBUTES, {...this.getValidatedAttribute(attribute)});
+    try {
+      sendToReporter(EVENTS.RP_TEST_ATTRIBUTES, {...this.getValidatedAttribute(attribute)});
+    } catch (e) {
+      log.error("An error occured when adding attribute")
+      log.error(e)
+    }
   }
 
   public static addAttributeToSuite(attribute: Attribute) {
-    sendToReporter(EVENTS.RP_SUITE_ATTRIBUTES, {...this.getValidatedAttribute(attribute)});
+    try {
+      sendToReporter(EVENTS.RP_SUITE_ATTRIBUTES, {...this.getValidatedAttribute(attribute)});
+    } catch (e) {
+      log.error("An error occured when adding attribute to suite")
+      log.error(e)
+    }
   }
 
   private static reporterName = "reportportal";


### PR DESCRIPTION
## Proposed changes

This PR adds a new reporter option — `throwOnReportingError`. When set to `true`, exceptions will be allowed to bubble up to the testing suite using this reporter. This is the default behavior. When set to `false`, exceptions will be caught, logged, and suppressed.

