### PR TITLE
Allow testCaseId to default to codeRef which is not affected by process path as prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const conf = {
   cucumberNestedSteps: false, // report cucumber steps as Report Portal steps
   autoAttachCucumberFeatureToScenario: false, // requires cucumberNestedSteps to be true for use
   sanitizeErrorMessages: true, // strip color ascii characters from error stacktrace
+  useFullPathCodeRef: true, // prefix file path with process file path, may need to disable for ci
   sauceLabOptions : {
     enabled: true, // automatically add SauseLab ID to rp tags.
     sldc: "US" // automatically add SauseLab region to rp tags.

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -27,9 +27,10 @@ export default class ReporterOptions {
   public seleniumCommandsLogLevel = LEVEL.DEBUG;
   public parseTagsFromTestTitle = false;
   public setRetryTrue = false;
-  public sauceLabOptions?: SauceLabOptions
+  public sauceLabOptions?: SauceLabOptions;
   public cucumberNestedSteps = false;
   public autoAttachCucumberFeatureToScenario = false;
   public sanitizeErrorMessages = true;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, attributes: [Attribute], description: ""};
+  public useFullPathCodeRef = true;
 }

--- a/lib/__tests__/utils.spec.ts
+++ b/lib/__tests__/utils.spec.ts
@@ -148,7 +148,13 @@ describe("#addSauceLabAttributes", () => {
 });
 
 describe("#addCodeRef", () => {
-  test("should add code reference to the test item", () => {
+  test("should add code reference with full process path to the test item", () => {
+    const testStartObj = new StartTestItem("foo", TYPE.TEST);
+    addCodeRef("example.spec.js", "foobar", testStartObj, true);
+    expect(testStartObj.codeRef).toEqual(`example.spec.js:foobar`);
+  });
+
+  test("should add code reference without full process path to the test item", () => {
     const testStartObj = new StartTestItem("foo", TYPE.TEST);
     addCodeRef("example.spec.js", "foobar", testStartObj);
     expect(testStartObj.codeRef).toEqual(`example.spec.js:foobar`);
@@ -156,11 +162,19 @@ describe("#addCodeRef", () => {
 });
 
 describe("#addCodeRefCucumber", () => {
-  test("should add code reference to the test item", () => {
+  test("should add code reference with full process path to the test item", () => {
     const testStartObj = new StartTestItem("foo", TYPE.TEST);
     const test = {title: "foobar", uid: "baz"}
     // @ts-ignore
-    addCodeRefCucumber("example.spec.js", test, testStartObj);
+    addCodeRefCucumber("example.spec.js", test, testStartObj, true);
+    expect(testStartObj.codeRef).toEqual(`example.spec.js:baz`);
+  });
+
+  test("should add code reference without full process path to the test item", () => {
+    const testStartObj = new StartTestItem("foo", TYPE.TEST);
+    const test = {title: "foobar", uid: "baz"}
+    // @ts-ignore
+    addCodeRefCucumber("example.spec.js", test, testStartObj, false);
     expect(testStartObj.codeRef).toEqual(`example.spec.js:baz`);
   });
 });

--- a/lib/__tests__/utils.spec.ts
+++ b/lib/__tests__/utils.spec.ts
@@ -156,7 +156,7 @@ describe("#addCodeRef", () => {
 
   test("should add code reference without full process path to the test item", () => {
     const testStartObj = new StartTestItem("foo", TYPE.TEST);
-    addCodeRef("example.spec.js", "foobar", testStartObj);
+    addCodeRef("example.spec.js", "foobar", testStartObj, false);
     expect(testStartObj.codeRef).toEqual(`example.spec.js:foobar`);
   });
 });

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -208,9 +208,9 @@ class ReportPortalReporter extends Reporter {
     const suite = this.storage.getCurrentSuite();
     const testStartObj = new StartTestItem(test.title, type);
     if(this.isCucumberFramework) {
-      addCodeRefCucumber(this.specFilePath, test, testStartObj)
+      addCodeRefCucumber(this.specFilePath, test, testStartObj, this.reporterOptions.useuseFullPathCodeRef);
     } else {
-      addCodeRef(this.specFilePath, test.fullTitle, testStartObj)
+      addCodeRef(this.specFilePath, test.fullTitle, testStartObj, this.reporterOptions.useFullPathCodeRef);
     }
     if (this.reporterOptions.cucumberNestedSteps) {
       testStartObj.hasStats = false;

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -208,7 +208,7 @@ class ReportPortalReporter extends Reporter {
     const suite = this.storage.getCurrentSuite();
     const testStartObj = new StartTestItem(test.title, type);
     if(this.isCucumberFramework) {
-      addCodeRefCucumber(this.specFilePath, test, testStartObj, this.reporterOptions.useuseFullPathCodeRef);
+      addCodeRefCucumber(this.specFilePath, test, testStartObj, this.reporterOptions.useFullPathCodeRef);
     } else {
       addCodeRef(this.specFilePath, test.fullTitle, testStartObj, this.reporterOptions.useFullPathCodeRef);
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -116,13 +116,13 @@ export const sendToReporter = (event: any, msg = {}) => {
 
 export const getRelativePath = (val: string) => val.replace(`${process.cwd()}${path.sep}`, '').trim()
 
-export const addCodeRef = (specFilePath: string, testname: string, testItem: StartTestItem) => {
-  testItem.codeRef = `${ReporterOptions.useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${testname}`;
+export const addCodeRef = (specFilePath: string, testname: string, testItem: StartTestItem, useFullPathCodeRef: boolean) => {
+  testItem.codeRef = `${useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${testname}`;
 };
 
-export const addCodeRefCucumber = (specFilePath: string, test: TestStats, testItem: StartTestItem) => {
+export const addCodeRefCucumber = (specFilePath: string, test: TestStats, testItem: StartTestItem, useFullPathCodeRef: boolean) => {
   const testTitleNoKeyword = test.title.replace(/^(Given|When|Then|And) /g, '').trim();
-  testItem.codeRef = `${ReporterOptions.useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${test.uid.replace(testTitleNoKeyword, '').trim()}`;
+  testItem.codeRef = `${useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${test.uid.replace(testTitleNoKeyword, '').trim()}`;
 }
 
 export function ansiRegex () {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -117,12 +117,12 @@ export const sendToReporter = (event: any, msg = {}) => {
 export const getRelativePath = (val: string) => val.replace(`${process.cwd()}${path.sep}`, '').trim()
 
 export const addCodeRef = (specFilePath: string, testname: string, testItem: StartTestItem) => {
-  testItem.codeRef = `${getRelativePath(specFilePath)}:${testname}`;
+  testItem.codeRef = `${ReporterOptions.useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${testname}`;
 };
 
 export const addCodeRefCucumber = (specFilePath: string, test: TestStats, testItem: StartTestItem) => {
   const testTitleNoKeyword = test.title.replace(/^(Given|When|Then|And) /g, '').trim();
-  testItem.codeRef = `${getRelativePath(specFilePath)}:${test.uid.replace(testTitleNoKeyword, '').trim()}`;
+  testItem.codeRef = `${ReporterOptions.useFullPathCodeRef ? getRelativePath(specFilePath) : specFilePath}:${test.uid.replace(testTitleNoKeyword, '').trim()}`;
 }
 
 export function ansiRegex () {


### PR DESCRIPTION
## Proposed changes
This change will allow to opt out of prefixing the codeRef with the process file path e.g: "codebuild/sr123/test/wdio/features/home/HomePage.feature" and instead resolve to "test/wdio/features/home/HomePage.feature" because some build servers like AWS codebuild uses arbitrary folder names each time and this breaks the linking of ReportPortal and all its cool features basically.

Often we don't specify testCaseId and it gets set to the codeRef so the codeRef needs to be configurable to ensure it can be reliable across launches and not be hindered by CI build server including random path each time
