### PR TITLE
Allow testCaseId to default to codeRef which is not affected by process path as prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const conf = {
   cucumberNestedSteps: false, // report cucumber steps as Report Portal steps
   autoAttachCucumberFeatureToScenario: false, // requires cucumberNestedSteps to be true for use
   sanitizeErrorMessages: true, // strip color ascii characters from error stacktrace
+  useScenarioNameAsCodeRef: false, // For cucumber, opt to set codeRef and testCaseId to scenario name
   sauceLabOptions : {
     enabled: true, // automatically add SauseLab ID to rp tags.
     sldc: "US" // automatically add SauseLab region to rp tags.

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -1,4 +1,4 @@
-useScenarioNameAsCodeRefimport {LEVEL, MODE} from "./constants";
+import {LEVEL, MODE} from "./constants";
 
 export class Attribute {
   public key?: string;

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -1,4 +1,4 @@
-import {LEVEL, MODE} from "./constants";
+useScenarioNameAsCodeRefimport {LEVEL, MODE} from "./constants";
 
 export class Attribute {
   public key?: string;
@@ -31,5 +31,6 @@ export default class ReporterOptions {
   public cucumberNestedSteps = false;
   public autoAttachCucumberFeatureToScenario = false;
   public sanitizeErrorMessages = true;
+  public useScenarioNameAsCodeRef = false;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, attributes: [Attribute], description: ""};
 }

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -213,7 +213,7 @@ describe("startSuite", () => {
         name: "foo",
         type: TYPE.STEP,
         retry: false,
-        codeRef: "FooBarSuite scenario"
+        codeRef: ""
       },
       reporter.tempLaunchId,
       id,

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -182,4 +182,41 @@ describe("startSuite", () => {
       id,
     );
   });
+
+  
+  test("should set codeRef to scenario name when useScenarioNameAsCodeRef option set to true", () => {
+    Object.assign(reporter.reporterOptions, {useScenarioNameAsCodeRef: true});
+    reporter.sessionId = "bar";
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.FEATURE}));
+    reporter.onSuiteStart(Object.assign(suiteStartEvent(), {type: CUCUMBER_TYPE.SCENARIO}));
+
+    expect(reporter.client.startTestItem).toBeCalledTimes(2);
+    expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
+      1,
+      {
+        description: "",
+        attributes: [],
+        name: "foo",
+        type: TYPE.TEST,
+        retry: false
+      },
+      reporter.tempLaunchId,
+      null,
+    );
+
+    const {id} = reporter.storage.getCurrentSuite();
+    expect(reporter.client.startTestItem).toHaveBeenNthCalledWith(
+      2,
+      {
+        description: "",
+        attributes: [],
+        name: "foo",
+        type: TYPE.STEP,
+        retry: false,
+        codeRef: "FooBarSuite scenario"
+      },
+      reporter.tempLaunchId,
+      id,
+    );
+  });
 });

--- a/lib/__tests__/startSuite.spec.ts
+++ b/lib/__tests__/startSuite.spec.ts
@@ -183,7 +183,6 @@ describe("startSuite", () => {
     );
   });
 
-  
   test("should set codeRef to scenario name when useScenarioNameAsCodeRef option set to true", () => {
     Object.assign(reporter.reporterOptions, {useScenarioNameAsCodeRef: true});
     reporter.sessionId = "bar";

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -133,7 +133,7 @@ class ReportPortalReporter extends Reporter {
       addSauceLabAttributes(this.reporterOptions, suiteStartObj, this.sessionId);
     }
     if (isCucumberScenario) {
-      suiteStartObj.codeRef = getRelativePath(this.specFilePath) + ':' + suite.uid.replace(suite.title, '').trim();
+      suiteStartObj.codeRef = this.reporterOptions.useScenarioNameAsCodeRef ? suite.title :  getRelativePath(this.specFilePath) + ':' + suite.uid.replace(suite.title, '').trim();
     }
     if (this.reporterOptions.cucumberNestedSteps && this.reporterOptions.autoAttachCucumberFeatureToScenario) {
       switch (suite.type) {


### PR DESCRIPTION
## Proposed changes
This change will allow to opt out of prefixing the codeRef with the process file path e.g: "codebuild/sr123/test/wdio/features/home/HomePage.feature" and instead resolve to "As a US Customer User I should be able to view documentation" because some build servers like AWS codebuild uses arbitrary folder names each time and this breaks the linking of ReportPortal and all its cool features basically.
Often we don't specify testCaseId and it gets set to the codeRef so the codeRef needs to be configurable to ensure it can be reliable across launches and not be hindered by CI build server including random path each time



