### PR TITLE
Adding addBrowserParam option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const conf = {
   cucumberNestedSteps: false, // report cucumber steps as Report Portal steps
   autoAttachCucumberFeatureToScenario: false, // requires cucumberNestedSteps to be true for use
   sanitizeErrorMessages: true, // strip color ascii characters from error stacktrace
+  addBrowserParam: true, // add browser param on test item
   sauceLabOptions : {
     enabled: true, // automatically add SauseLab ID to rp tags.
     sldc: "US" // automatically add SauseLab region to rp tags.

--- a/lib/ReporterOptions.ts
+++ b/lib/ReporterOptions.ts
@@ -32,4 +32,5 @@ export default class ReporterOptions {
   public autoAttachCucumberFeatureToScenario = false;
   public sanitizeErrorMessages = true;
   public reportPortalClientConfig = {mode: MODE.DEFAULT, attributes: [Attribute], description: ""};
+  public addBrowserParam = true;
 }

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -223,7 +223,9 @@ class ReportPortalReporter extends Reporter {
     if (this.reporterOptions.setRetryTrue) {
       testStartObj.retry = true;
     }
-    addBrowserParam(this.sanitizedCapabilities, testStartObj);
+    if (this.reporterOptions.addBrowserParam) {
+      addBrowserParam(this.sanitizedCapabilities, testStartObj);
+    }
 
     const {tempId, promise} = this.client.startTestItem(
       testStartObj,


### PR DESCRIPTION
This PR adds a new option to disable the automatic injection of the browser parameter into test items in wdio-reportportal-reporter.
In mobile testing (e.g., Appium), dynamic browserName values based on device UDIDs were causing different testCaseIds for the same tests, breaking history tracking in ReportPortal.
By disabling addBrowserParam, users can ensure stable test IDs across runs and maintain consistent test history.
This change improves flexibility for non-browser testing environments without affecting existing behavior by default.

